### PR TITLE
Adding Middlewares to Pine router

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,28 @@ p.Handle("/hello/{name}", func(w http.ResponseWriter, r *http.Request) {
 log.Fatalln(http.ListenAndServe(":8080", p))
 ```
 
+### Handler Routing
+All handlers are parsed in first to last definition order (e.g. if you have a variable in the folder defined first that will run first)
+
+
+### Middlewares
+Gorilla/Mux style middlewares are supported by the type `pine.MiddlewareFunc` which is just a `func(http.Handler) http.Handler` under the hood.
+
+Usage:
+```go
+p := pine.New()
+p.Use(func(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		// make sure to call `next` otherwise the handler will not get called
+		next.ServeHTTP(w, r)
+	})
+})
+```
+Note: Middlewares are run in order of being added
+
+There are a few pre-made middlewares that are defined in the `middlewares` package such as:
+* `middlewares.HTTPLogger` Logs the HTTP Request/Responses in the following format: `2023/04/02 12:48:37 host: localhost:8080 method: GET uri: / status: 200 Ok`
 
 
 ## Scope

--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ Note: Middlewares are run in order of being added
 
 There are a few pre-made middlewares that are defined in the `middlewares` package such as:
 * `middlewares.HTTPLogger` Logs the HTTP Request/Responses in the following format: `2023/04/02 12:48:37 host: localhost:8080 method: GET uri: / status: 200 Ok`
+* `middlewares.STolinskiTiming` Puts the requests into different time buckets such based on the (slow, middle) durations passed. Inserts a `X-Duration` header to based on those timing buckets
 
 
 ## Scope
 * [x] routing based on paths
 * [x] variables on paths
-* [ ] middlewares
+* [x] middlewares
 
 
 ### Soundtrack while developing this project

--- a/examples/hello-world/main.go
+++ b/examples/hello-world/main.go
@@ -6,11 +6,13 @@ import (
 	"github.com/lukasmwerner/pine/middlewares"
 	"log"
 	"net/http"
+	"time"
 )
 
 func main() {
 	r := pine.New()
 	r.Use(middlewares.HTTPLogger())
+	r.Use(middlewares.STolinskiTiming(time.Second, time.Second/2))
 	r.Handle("/hello/home", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Write([]byte(fmt.Sprint("welcome home!")))

--- a/examples/hello-world/main.go
+++ b/examples/hello-world/main.go
@@ -3,12 +3,14 @@ package main
 import (
 	"fmt"
 	"github.com/lukasmwerner/pine"
+	"github.com/lukasmwerner/pine/middlewares"
 	"log"
 	"net/http"
 )
 
 func main() {
 	r := pine.New()
+	r.Use(middlewares.HTTPLogger())
 	r.Handle("/hello/home", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Write([]byte(fmt.Sprint("welcome home!")))

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,61 @@
+package pine
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAddingMiddleware(t *testing.T) {
+	p := New()
+	if len(p.Middlewares) != 0 {
+		t.Errorf("middlewares was not expected length %d, instead was %d", 0, len(p.Middlewares))
+	}
+
+	p.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r)
+		})
+	})
+
+	if len(p.Middlewares) != 1 {
+		t.Errorf("middlewares was not expected length %d, instead was %d", 1, len(p.Middlewares))
+	}
+}
+
+func TestMiddlewareEarlyReturn(t *testing.T) {
+	p := New()
+	p.Use(func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/" {
+				w.Write([]byte("hello from middleware"))
+			} else {
+				next.ServeHTTP(w, r)
+			}
+		})
+	})
+	p.Handle("/testing", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("hello from handler"))
+	})
+
+	req := httptest.NewRequest("GET", "https://lukaswerner.com/", nil)
+	resp := httptest.NewRecorder()
+	p.ServeHTTP(resp, req)
+
+	result := resp.Result()
+	if b, _ := io.ReadAll(result.Body); bytes.Compare(b, []byte("hello from middleware")) != 0 {
+		t.Errorf("the body response did not match the expected body: %s != %s", string(b), "hello from middleware")
+	}
+
+	req = httptest.NewRequest("GET", "https://lukaswerner.com/testing", nil)
+	resp = httptest.NewRecorder()
+	p.ServeHTTP(resp, req)
+
+	result = resp.Result()
+	if b, _ := io.ReadAll(result.Body); bytes.Compare(b, []byte("hello from handler")) != 0 {
+		t.Errorf("the body response did not match the expected body: %s != %s", string(b), "hello from handler")
+	}
+
+}

--- a/middlewares/logger.go
+++ b/middlewares/logger.go
@@ -11,6 +11,9 @@ type LoggerConfig struct {
 	l *log.Logger
 }
 
+// HTTPLogger Logs the HTTP Request/Responses in the following
+//
+// format: 2023/04/02 12:48:37 host: localhost:8080 method: GET uri: / status: 200 Ok
 func HTTPLogger() pine.MiddlewareFunc {
 	c := LoggerConfig{}
 	c.l = log.Default()

--- a/middlewares/logger.go
+++ b/middlewares/logger.go
@@ -1,0 +1,43 @@
+package middlewares
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/lukasmwerner/pine"
+)
+
+type LoggerConfig struct {
+	l *log.Logger
+}
+
+func HTTPLogger() pine.MiddlewareFunc {
+	c := LoggerConfig{}
+	c.l = log.Default()
+	c.l.SetFlags(log.Ldate | log.Ltime)
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			lw := &loggingWriter{w, 200}
+			next.ServeHTTP(lw, r)
+			c.l.Printf(
+				"host: %s method: %s uri: %s status: %d %s\n",
+				r.Host,
+				r.Method,
+				r.URL.RequestURI(),
+				lw.statusCode,
+				http.StatusText(lw.statusCode),
+			)
+		})
+	}
+}
+
+type loggingWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (l *loggingWriter) WriteHeader(code int) {
+	l.statusCode = code
+	l.ResponseWriter.WriteHeader(code)
+}

--- a/middlewares/stolinski_timing.go
+++ b/middlewares/stolinski_timing.go
@@ -40,6 +40,14 @@ func (wb *responseWriterBuffer) Copy(w http.ResponseWriter) {
 	io.Copy(w, wb.bodyBuffer)
 }
 
+// STolinskiTiming (slow, middle) is a middleware that buckets the time it takes for http responses
+// to get fullfilled. If the request is slower than the slow time then it inserts a turtle...
+// into the X-Duration header and if it is faster than the slow and slower than middle
+// then it gets a rabbit.. in the header otherwise it gets a rocket!
+//
+// example:
+// p := pine.New()
+// p.Use(middlewares.STolinskiTiming(time.Second, time.Second/3))
 func STolinskiTiming(slow time.Duration, middle time.Duration) pine.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/middlewares/stolinski_timing.go
+++ b/middlewares/stolinski_timing.go
@@ -1,0 +1,65 @@
+package middlewares
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/lukasmwerner/pine"
+)
+
+type responseWriterBuffer struct {
+	bodyBuffer *bytes.Buffer
+	headers    http.Header
+	statusCode int
+}
+
+func (w *responseWriterBuffer) Write(b []byte) (int, error) {
+	if w.statusCode == 0 {
+		w.statusCode = 200
+	}
+	return w.bodyBuffer.Write(b)
+}
+func (w *responseWriterBuffer) Header() http.Header {
+	return w.headers
+}
+func (w *responseWriterBuffer) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}
+
+func (wb *responseWriterBuffer) Copy(w http.ResponseWriter) {
+	// Copy all the headers
+	for k, vs := range wb.Header() {
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+
+	w.WriteHeader(wb.statusCode)
+	io.Copy(w, wb.bodyBuffer)
+}
+
+func STolinskiTiming(slow time.Duration, middle time.Duration) pine.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+			rspWB := &responseWriterBuffer{
+				bodyBuffer: bytes.NewBuffer(nil),
+			}
+
+			start := time.Now()
+			next.ServeHTTP(rspWB, r)
+			finish := time.Now()
+			duration := finish.Sub(start)
+			w.Header().Set("X-Duration", "rocket!")
+			if duration.Microseconds() >= slow.Microseconds() {
+				w.Header().Set("X-Duration", "turtle...")
+			}
+			if duration.Microseconds() < slow.Microseconds() && duration.Microseconds() >= middle.Microseconds() {
+				w.Header().Set("X-Duration", "rabbit..")
+			}
+			rspWB.Copy(w)
+		})
+	}
+}


### PR DESCRIPTION
Gorilla/Mux style middlewares are supported by the type `pine.MiddlewareFunc` which is just a `func(http.Handler) http.Handler` under the hood.

Usage:
```go
p := pine.New()
p.Use(func(next http.Handler) http.Handler {
	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

		// make sure to call `next` otherwise the handler will not get called
		next.ServeHTTP(w, r)
	})
})
```
Note: Middlewares are run in order of being added

There are a few pre-made middlewares that are defined in the `middlewares` package such as:
* `middlewares.HTTPLogger` Logs the HTTP Request/Responses in the following format: `2023/04/02 12:48:37 host: localhost:8080 method: GET uri: / status: 200 Ok`

I still have a few plans for adding more middlewares but that requires more research that I don't want to put in right now.